### PR TITLE
removed tampermonkey errors and improved username recognition

### DIFF
--- a/chat/message_parents/message_parents_popup.user.js
+++ b/chat/message_parents/message_parents_popup.user.js
@@ -89,7 +89,7 @@ var getIdOfSelectedParentMessage = function() {
 var replaceUserNameWithSelectedParentMessageAndClosePopup = function() {
     var input = document.getElementById('input');
     var parentId = getIdOfSelectedParentMessage();
-    input.value = input.value.replace(/^\s*(\@[\wа-яё]+)/i, ":" + parentId);
+    input.value = input.value.replace(/^\s*(\@[\wа-яё.-]+)/i, ":" + parentId);
     closeParentMessagesPopup();
 };
 

--- a/chat/message_parents/message_parents_popup.user.js
+++ b/chat/message_parents/message_parents_popup.user.js
@@ -11,58 +11,59 @@
 // ==/UserScript==
 
 
-var getUserNameFromContainer = function(c) { 
-    return normalizeUserName(c.querySelector(".username").textContent); 
-}
+var getUserNameFromContainer = function(c) {
+    return normalizeUserName(c.querySelector(".username").textContent);
+};
 
-var getUserMessages = function(username) { 
-    var prefix = username[0] == '@' ? '@' : ''; 
-    return $("div.monologue").filter(function (i, c) { 
-        return (prefix + getUserNameFromContainer(c)) == normalizeUserName(username); 
-    }); 
-}
+var getUserMessages = function(username) {
+    var prefix = username[0] == '@' ? '@' : '';
+    return $("div.monologue").filter(function (i, c) {
+        var containerName = getUserNameFromContainer(c).replace(/\u{200B}/ug, '').replace(/\u{2011}/ug, '-');
+        return (prefix + containerName) == normalizeUserName(username);
+    });
+};
 
-var getMessagesFromContainer = function(c) { 
+var getMessagesFromContainer = function(c) {
     return $.map($(c).find(".message"), function(m) {
         return {
             pid: m.id.split('-')[1],
-            content: m.querySelector('.content').textContent}; 
-        }); 
-}
+            content: m.querySelector('.content').textContent};
+        });
+};
 
-var getUserNameFromNewMessage = function() { 
+var getUserNameFromNewMessage = function() {
     var message = document.getElementById('input').value;
-    var username = /^\s*\@([\wа-яё]+)/i.exec(message);
+    var username = /^\s*\@([\wа-яё.-]+)/i.exec(message);
     return username != null ? username[1] : null;
-}
+};
 
-var convertMessageToHtml = function (m) { 
-    return '<div class="message" id="_message-' + m.pid + '">' + 
-               '<div class="content">' + m.content + '</div></div>'; 
-}
+var convertMessageToHtml = function (m) {
+    return '<div class="message" id="_message-' + m.pid + '">' +
+               '<div class="content">' + m.content + '</div></div>';
+};
 
 var createParentMessagesPopupHtml = function(username) {
     return '<div class="popup" id="parent-messages-popup" ' +
-                'style="left: 100px; bottom: 100px; width:60%;">' + 
-                    Array.from(getUserMessages(username).map(function (i, c) { 
-                        return getMessagesFromContainer(c); 
-                    }).map(function(i, m) { 
-                        return convertMessageToHtml(m); 
-                    })).join('') + 
+                'style="left: 100px; bottom: 100px; width:60%;">' +
+                    Array.from(getUserMessages(username).map(function (i, c) {
+                        return getMessagesFromContainer(c);
+                    }).map(function(i, m) {
+                        return convertMessageToHtml(m);
+                    })).join('') +
            '</div>';
-}
+};
 
 var getParentMessagesPopup = function() {
     return $("#parent-messages-popup");
-}
+};
 
 var isParentMessagesPopupOpen = function() {
     return getParentMessagesPopup().size() > 0;
-}
+};
 
 var closeParentMessagesPopup = function() {
     getParentMessagesPopup().remove();
-}
+};
 
 var openParentMessagesPopup = function(username) {
     if(isParentMessagesPopupOpen()) {
@@ -71,30 +72,30 @@ var openParentMessagesPopup = function(username) {
 
     $('body').append(createParentMessagesPopupHtml(username));
     getParentMessagesPopup().find(".message").last().addClass("reply-parent");
-}
+};
 
 var moveParentMessageSelectionUp = function() {
     getParentMessagesPopup().find(".reply-parent").prev().addClass("reply-parent").next().removeClass("reply-parent");
-} 
+};
 
 var moveParentMessageSelectionDown = function() {
     getParentMessagesPopup().find(".reply-parent").next().addClass("reply-parent").prev().removeClass("reply-parent");
-} 
+};
 
 var getIdOfSelectedParentMessage = function() {
     return getParentMessagesPopup().find(".reply-parent")[0].id.split('-')[1];
-}
+};
 
 var replaceUserNameWithSelectedParentMessageAndClosePopup = function() {
     var input = document.getElementById('input');
     var parentId = getIdOfSelectedParentMessage();
     input.value = input.value.replace(/^\s*(\@[\wа-яё]+)/i, ":" + parentId);
     closeParentMessagesPopup();
-}
+};
 
 document.getElementById('input').addEventListener('keydown', function (e) {
     if(!isParentMessagesPopupOpen()) {
-        if(e.keyIdentifier == 'U+0020' && e.ctrlKey) { 
+        if(e.keyIdentifier == 'U+0020' && e.ctrlKey) {
             var username = getUserNameFromNewMessage();
             if(username != null) {
                 openParentMessagesPopup(username);


### PR DESCRIPTION
tampermonkey showed errors when a variable declaration wasn't terminated by a semicolon.
tampermonkey also marked whitespaces at the end of a line red.
so i added semicolons after every variable declaration and removed whitespaces at the end of a line.

i also improved the recognition of usernames.
the chat webpage sometimes adds characters (zero-width whitespace) or replaces the character '-' with a nonbreaking hyphen.
these are either removed or replaced now.
hyphens and dots can be part of a username but weren't taken into account.
so i improved the regex for it.
